### PR TITLE
Add # words, strokes, and detailed translation search

### DIFF
--- a/plover/gui_qt/dictionary_editor.py
+++ b/plover/gui_qt/dictionary_editor.py
@@ -1,4 +1,4 @@
-
+import re
 from operator import attrgetter, itemgetter
 from collections import namedtuple
 from itertools import chain
@@ -10,16 +10,16 @@ from PyQt5.QtCore import (
     QAbstractTableModel,
     QModelIndex,
     Qt,
-)
+    QPoint)
 from PyQt5.QtWidgets import (
     QComboBox,
     QDialog,
     QStyledItemDelegate,
-)
+    QToolTip)
 
 from plover.translation import escape_translation, unescape_translation
 from plover.misc import expand_path, shorten_path
-from plover.steno import normalize_steno
+from plover.steno import normalize_steno, filter_entry
 
 from plover.gui_qt.dictionary_editor_ui import Ui_DictionaryEditor
 from plover.gui_qt.utils import ToolBar, WindowState
@@ -61,18 +61,16 @@ class DictionaryItemModel(QAbstractTableModel):
         self._sort_order = sort_order
         self._update_entries()
 
-    def _update_entries(self, strokes_filter=None, translation_filter=None):
+    def _update_entries(self, strokes_filter=None, translation_filter=None,
+                        case_sensitive=False, regex=None):
         self._entries = []
         for dictionary in self._dictionary_list:
             for strokes, translation in iteritems(dictionary):
-                if strokes_filter is not None and \
-                   not '/'.join(strokes).startswith(strokes_filter):
-                    continue
-                if translation_filter is not None and \
-                   not translation.startswith(translation_filter):
-                    continue
-                item = DictionaryItem(strokes, translation, dictionary)
-                self._entries.append(item)
+                if filter_entry(strokes, translation, strokes_filter,
+                                translation_filter, case_sensitive, regex):
+                    self._entries.append(
+                        DictionaryItem(strokes, translation, dictionary)
+                    )
         self.sort(self._sort_column, self._sort_order)
 
     @property
@@ -152,7 +150,7 @@ class DictionaryItemModel(QAbstractTableModel):
         return 0 if parent.isValid() else len(self._entries)
 
     def columnCount(self, parent):
-        return 3
+        return 5
 
     def headerData(self, section, orientation, role):
         if orientation != Qt.Horizontal or role != Qt.DisplayRole:
@@ -163,6 +161,10 @@ class DictionaryItemModel(QAbstractTableModel):
             return _('Translation')
         if section == 2:
             return _('Dictionary')
+        if section == 3:
+            return _('# Strokes')
+        if section == 4:
+            return _('# Words')
 
     def data(self, index, role):
         if not index.isValid() or role not in (Qt.EditRole, Qt.DisplayRole):
@@ -175,21 +177,33 @@ class DictionaryItemModel(QAbstractTableModel):
             return escape_translation(item.translation)
         if column == 2:
             return shorten_path(item.dictionary.get_path())
+        if column == 3:
+            return len(item.strokes)
+        if column == 4:
+            return len(item.translation.split(' '))
 
     def flags(self, index):
         if not index.isValid():
             return Qt.NoItemFlags
-        return Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable
+        editable = Qt.ItemIsEditable if index.column() <= 2 else 0
+        return Qt.ItemIsEnabled | Qt.ItemIsSelectable | editable
 
-    def filter(self, strokes_filter=None, translation_filter=None):
+    def filter(self, strokes_filter=None, translation_filter=None,
+               case_sensitive=False, regex=None):
         self.modelAboutToBeReset.emit()
-        self._update_entries(strokes_filter, translation_filter)
+        self._update_entries(
+            strokes_filter, translation_filter, case_sensitive, regex
+        )
         self.modelReset.emit()
 
     def sort(self, column, order):
         self.layoutAboutToBeChanged.emit()
         if column == 2:
             key = attrgetter('dictionary_path')
+        elif column == 3:
+            key = lambda entry: len(entry.strokes)
+        elif column == 4:
+            key = lambda entry: len(entry.translation.split(' '))
         else:
             key = itemgetter(column)
         self._entries.sort(key=key,
@@ -290,7 +304,11 @@ class DictionaryEditor(QDialog, Ui_DictionaryEditor, WindowState):
         self.table.sortByColumn(sort_column, sort_order)
         self.table.setModel(self._model)
         self.table.setSortingEnabled(True)
-        self.table.resizeColumnsToContents()
+        self.table.setColumnWidth(0, 200)
+        self.table.setColumnWidth(1, 200)
+        self.table.setColumnWidth(2, 200)
+        self.table.resizeColumnToContents(3)
+        self.table.resizeColumnToContents(4)
         self.table.setItemDelegate(DictionaryItemDelegate(dictionary_list))
         self.table.selectionModel().selectionChanged.connect(self.on_selection_changed)
         background = self.table.palette().highlightedText().color().name()
@@ -363,14 +381,36 @@ class DictionaryEditor(QDialog, Ui_DictionaryEditor, WindowState):
 
     def on_apply_filter(self):
         strokes_filter = '/'.join(normalize_steno(self.strokes_filter.text().strip()))
-        translation_filter = unescape_translation(self.translation_filter.text().strip())
-        self._model.filter(strokes_filter=strokes_filter,
-                           translation_filter=translation_filter)
+        translation_filter = self.translation_filter.text()
+        unescaped_translation_filter = unescape_translation(translation_filter)
+        case_sensitive = self.case_checkbox.checkState()
+        is_regex = self.regex_checkbox.checkState()
+        try:
+            regex = re.compile(
+                translation_filter, flags=0 if case_sensitive else re.I
+            ) if is_regex else None
+        except re.error as e:
+            # Invalid regex, don't apply filter.
+            QToolTip.showText(
+                self.translation_filter.mapToGlobal(QPoint(0,0)),
+                'RegEx did not compile: %s' % str(e)
+            )
+            return
+        else:
+            # Regex overrides some other filter criteria
+            if regex:
+                unescaped_translation_filter=None
+                strokes_filter=None
+                case_sensitive=None
+        self._model.filter(strokes_filter, unescaped_translation_filter,
+                           case_sensitive, regex)
 
     def on_clear_filter(self):
         self.strokes_filter.setText('')
         self.translation_filter.setText('')
-        self._model.filter(strokes_filter=None, translation_filter=None)
+        self.case_checkbox.setChecked(False)
+        self.regex_checkbox.setChecked(False)
+        self._model.filter()
 
     def on_finished(self, result):
         with self._engine:

--- a/plover/gui_qt/dictionary_editor.ui
+++ b/plover/gui_qt/dictionary_editor.ui
@@ -32,8 +32,18 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="1" column="2">
+       <widget class="QPushButton" name="clear_button">
+        <property name="text">
+         <string>Clear</string>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0">
-       <widget class="QLabel" name="label">
+       <widget class="QLabel" name="stroke_label">
         <property name="text">
          <string>By strokes:</string>
         </property>
@@ -43,7 +53,7 @@
        <widget class="QLineEdit" name="strokes_filter"/>
       </item>
       <item row="0" column="2">
-       <widget class="QPushButton" name="pushButton">
+       <widget class="QPushButton" name="filter_button">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
           <horstretch>0</horstretch>
@@ -51,26 +61,43 @@
          </sizepolicy>
         </property>
         <property name="text">
-         <string>Apply</string>
+         <string>Filter</string>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>By translation:</string>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+        <property name="default">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
       <item row="1" column="1">
        <widget class="QLineEdit" name="translation_filter"/>
       </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="pushButton_2">
+      <item row="1" column="0">
+       <widget class="QLabel" name="translation_label">
         <property name="text">
-         <string>Clear</string>
+         <string>By translation:</string>
         </property>
        </widget>
+      </item>
+      <item row="2" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QCheckBox" name="case_checkbox">
+          <property name="text">
+           <string>Case sensitive</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="regex_checkbox">
+          <property name="text">
+           <string>RegEx</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -232,7 +259,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>pushButton</sender>
+   <sender>filter_button</sender>
    <signal>clicked()</signal>
    <receiver>DictionaryEditor</receiver>
    <slot>on_apply_filter()</slot>
@@ -280,7 +307,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>pushButton_2</sender>
+   <sender>clear_button</sender>
    <signal>clicked()</signal>
    <receiver>DictionaryEditor</receiver>
    <slot>on_clear_filter()</slot>

--- a/plover/steno.py
+++ b/plover/steno.py
@@ -47,6 +47,29 @@ def sort_steno_keys(steno_keys):
     return sorted(steno_keys, key=lambda x: system.KEY_ORDER.get(x, -1))
 
 
+def filter_entry(strokes, translation, strokes_filter=None,
+                 translation_filter=None, case_sensitive=False, regex=None):
+    joined_strokes = '/'.join(strokes)
+    # Two cases:
+    #   Looking for 'STPH' and get 'STPH/BA'
+    #   Looking for 'BA' and get 'STPH/BA'
+    if strokes_filter is not None and \
+       not joined_strokes.startswith(strokes_filter) and \
+            not '/' + strokes_filter in joined_strokes:
+        return False
+    if regex is not None:
+        if not regex.search(translation):
+            return False
+    elif translation_filter is not None:
+        translation_filter = translation_filter if case_sensitive\
+            else translation_filter.lower()
+        translation_text = translation if case_sensitive\
+            else translation.lower()
+        if translation_filter not in translation_text:
+            return False
+    return True
+
+
 class Stroke(object):
     """A standardized data model for stenotype machine strokes.
 

--- a/test/test_steno.py
+++ b/test/test_steno.py
@@ -2,10 +2,10 @@
 # See LICENSE.txt for details.
 
 """Unit tests for steno.py."""
-
+import re
 import unittest
 
-from plover.steno import normalize_steno, Stroke
+from plover.steno import normalize_steno, Stroke, filter_entry
 
 
 class StenoTestCase(unittest.TestCase):
@@ -59,3 +59,163 @@ class StenoTestCase(unittest.TestCase):
         self.assertEqual(Stroke(['-P', '-P']).rtfcre, '-P')
         self.assertEqual(Stroke(['-P', 'X-']).rtfcre, 'X-P')
         self.assertEqual(Stroke(['#', 'S-', '-T']).rtfcre, '1-9')
+
+    def test_filter_by_strokes(self):
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', strokes_filter=''
+        ))
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', strokes_filter='T'
+        ))
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', strokes_filter='TKOG'
+        ))
+
+        # Must start with
+        self.assertFalse(filter_entry(
+            ('TKOG',), 'dog', strokes_filter='KOG'
+        ))
+        # Must contain all of the filter
+        self.assertFalse(filter_entry(
+            ('TKOG',), 'dog', strokes_filter='TKOGS'
+        ))
+        # Must contain all strokes (partially)
+        self.assertFalse(filter_entry(
+            ('TKOG',), 'dog', strokes_filter='TKOG/S'
+        ))
+        self.assertTrue(filter_entry(
+            ('TKOG', 'SAEUD'), 'dog said', strokes_filter='TKOG/S'
+        ))
+        self.assertTrue(filter_entry(
+            ('TKOG', 'S',), 'dogs', strokes_filter='TKOG/S'
+        ))
+
+        # Can be in a phrase
+        self.assertTrue(filter_entry(
+            ('URP', 'TPHU', 'KWRORBG', 'STAEUT'),
+            'Upper New York State',
+            strokes_filter='TPHU/KWRORBG'
+        ))
+
+        # Interesting edge case: trailing slash.
+        self.assertTrue(filter_entry(
+            ('TKOG', 'S',), 'dogs', strokes_filter='TKOG/'
+        ))
+        self.assertFalse(filter_entry(
+            ('TKOG',), 'dog', strokes_filter='TKOG/'
+        ))
+
+    def test_filter_by_translation_plain(self):
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', translation_filter=''
+        ))
+        # Starts with
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', translation_filter='d'
+        ))
+        # Contains
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', translation_filter='o'
+        ))
+        # Ends with
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', translation_filter='g'
+        ))
+        # Whole
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', translation_filter='dog'
+        ))
+        # Case insensitive
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', translation_filter='DOG'
+        ))
+        # Nothing more
+        self.assertFalse(filter_entry(
+            ('TKOG',), 'dog', translation_filter='dogs'
+        ))
+
+    def test_filter_by_translation_case_sensitive(self):
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', translation_filter='', case_sensitive=True
+        ))
+        # Starts with
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', translation_filter='d', case_sensitive=True
+        ))
+        # Contains
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', translation_filter='o', case_sensitive=True
+        ))
+        # Ends with
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', translation_filter='g', case_sensitive=True
+        ))
+        # Whole
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', translation_filter='dog', case_sensitive=True
+        ))
+        # Case sensitive
+        self.assertFalse(filter_entry(
+            ('TKOG',), 'dog', translation_filter='DOG', case_sensitive=True
+        ))
+        self.assertFalse(filter_entry(
+            ('TKOG',), 'DOG', translation_filter='dog', case_sensitive=True
+        ))
+        # Nothing more
+        self.assertFalse(filter_entry(
+            ('TKOG',), 'dog', translation_filter='dogs', case_sensitive=True
+        ))
+
+    def test_filter_by_translation_regex(self):
+        # Regex should be None if the checkbox isn't checked.
+        def insensitive_regex(translation_filter):
+            return re.compile(translation_filter, flags=re.I)
+
+        def sensitive_regex(translation_filter):
+            return re.compile(translation_filter)
+
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', regex=insensitive_regex('')
+        ))
+        self.assertFalse(filter_entry(
+            ('TKOG',), 'dog', regex=insensitive_regex('^$')
+        ))
+        # Starts with
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', regex=insensitive_regex('^.*$')
+        ))
+        # Whole
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', regex=insensitive_regex('^dog$')
+        ))
+        # Missing whole
+        self.assertFalse(filter_entry(
+            ('TKOG',), 'dog', regex=insensitive_regex('^do$')
+        ))
+        self.assertFalse(filter_entry(
+            ('TKOG',), 'dog', regex=insensitive_regex('^og$')
+        ))
+        # Contains
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', regex=insensitive_regex('d')
+        ))
+        # Ends with
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', regex=insensitive_regex('d?g')
+        ))
+        # Whole
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', regex=insensitive_regex('d[^0]g')
+        ))
+        # Case insensitive
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', regex=insensitive_regex('DOG')
+        ))
+        # Case sensitive
+        self.assertFalse(filter_entry(
+            ('TKOG',), 'dog', regex=sensitive_regex('DOG')
+        ))
+        # Nothing more
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', regex=insensitive_regex('dog')
+        ))


### PR DESCRIPTION
### About
- # words and # strokes from Bozzy, re-added
- Filter strokes as "has a stroke starting with..." in its stroke list.
- Translation search supports case insensitive and regex flags and now searches in the translation instead of at the beginning.
### Reason

We are playing catchup with Bozzy features, while also adding the case-insensitive as an option and regex support which I've found myself wanting.

When the regex doesn't compile there's a handy little tooltip error.
### Tests

No tests written yet, considering pulling it out as a function for testing.
