### PR TITLE
Open dictionary editor in new window

### DIFF
--- a/plover/gui_qt/dictionary_editor.ui
+++ b/plover/gui_qt/dictionary_editor.ui
@@ -3,7 +3,7 @@
  <class>DictionaryEditor</class>
  <widget class="QDialog" name="DictionaryEditor">
   <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
+   <enum>Qt::NonModal</enum>
   </property>
   <property name="geometry">
    <rect>
@@ -18,6 +18,9 @@
   </property>
   <property name="sizeGripEnabled">
    <bool>true</bool>
+  </property>
+  <property name="modal">
+   <bool>false</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>


### PR DESCRIPTION
Fixes issue #10 

We should discuss whether it makes sense to make it a non-blocking window and allow opening multiple instances of the editor at once. I think if we implement the dictionary list allowing us to swap in and out the dictionaries which are visible in the editor, we won't need to support opening multiple editors at once.
