### PR TITLE
dictionary_editor: more loosely handle slashes as boundaries

### DIFF
--- a/plover/steno.py
+++ b/plover/steno.py
@@ -100,7 +100,8 @@ def sort_steno_keys(steno_keys):
 
 def filter_entry(strokes, translation, strokes_filter=None,
                  translation_filter=None, case_sensitive=False, regex=None):
-    joined_strokes = '/'.join(strokes)
+    # In the form: /STK/STK/ and /STK/
+    joined_strokes = '/' + '/'.join(strokes) + '/'
     # Two cases:
     #   Looking for 'STPH' and get 'STPH/BA'
     #   Looking for 'BA' and get 'STPH/BA'

--- a/test/test_steno.py
+++ b/test/test_steno.py
@@ -131,6 +131,20 @@ class StenoTestCase(unittest.TestCase):
         self.assertFalse(filter_entry(
             ('TKOG',), 'dog', strokes_filter='TKOGS'
         ))
+        # Boundaries count as beginning / endings
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', strokes_filter='TKOG/'
+        ))
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', strokes_filter='/TKOG/'
+        ))
+        self.assertTrue(filter_entry(
+            ('TKOG',), 'dog', strokes_filter='/TKOG'
+        ))
+        # Must contain all of the filter
+        self.assertFalse(filter_entry(
+            ('TKOG',), 'dog', strokes_filter='TKOGS'
+        ))
         # Must contain all strokes (partially)
         self.assertFalse(filter_entry(
             ('TKOG',), 'dog', strokes_filter='TKOG/S'
@@ -149,11 +163,11 @@ class StenoTestCase(unittest.TestCase):
             strokes_filter='TPHU/KWRORBG'
         ))
 
-        # Interesting edge case: trailing slash.
+        # Trailing slash.
         self.assertTrue(filter_entry(
             ('TKOG', 'S',), 'dogs', strokes_filter='TKOG/'
         ))
-        self.assertFalse(filter_entry(
+        self.assertTrue(filter_entry(
             ('TKOG',), 'dog', strokes_filter='TKOG/'
         ))
 


### PR DESCRIPTION
### About

Before filtering for strokes `/TED/` would only find entries with `TED` in the middle, e.g. `EU/TED/TKED`. Now it also returns `TED` itself.
### Issues

Fixes #14
### Reason

There was no way to search this otherwise.
