### PR TITLE
Add collisions and duplicates filtering

### DIFF
--- a/plover/gui_qt/dictionary_editor.py
+++ b/plover/gui_qt/dictionary_editor.py
@@ -1,6 +1,6 @@
 import re
 from operator import attrgetter, itemgetter
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 from itertools import chain
 
 # Python 2/3 compatibility.
@@ -37,6 +37,8 @@ class DictionaryItem(namedtuple('DictionaryItem', 'strokes translation dictionar
     def dictionary_path(self):
         return self.dictionary.get_path()
 
+    def __hash__(self):
+        return hash(self.strokes) + hash(self.translation)
 
 class DictionaryItemDelegate(QStyledItemDelegate):
 
@@ -68,15 +70,67 @@ class DictionaryItemModel(QAbstractTableModel):
         self._update_entries()
 
     def _update_entries(self, strokes_filter=None, translation_filter=None,
-                        case_sensitive=False, regex=None):
+                        case_sensitive=False, regex=None, collisions=False,
+                        duplicates=False):
         self._entries = []
+
+        entries_by_strokes = {}
+        entries_by_strokes_translation = {}
+        collided = False
+        duplicated = False
+
+        def filter_entry_custom(strokes, translation):
+            return filter_entry(
+                strokes, translation, strokes_filter, translation_filter,
+                case_sensitive, regex
+            )
         for dictionary in self._dictionary_list:
             for strokes, translation in iteritems(dictionary):
-                if filter_entry(strokes, translation, strokes_filter,
-                                translation_filter, case_sensitive, regex):
-                    self._entries.append(
-                        DictionaryItem(strokes, translation, dictionary)
-                    )
+                prior_entry = None
+                if collisions:
+                    # Include entries with matching strokes,
+                    # different translations.
+                    collided = False
+                    if strokes in entries_by_strokes:
+                        collision, new = entries_by_strokes[strokes]
+                        if collision.translation != translation:
+                            collided = True
+                            if new:
+                                prior_entry = collision
+                                entries_by_strokes[strokes] = (collision, False)
+                    else:
+                        entries_by_strokes[strokes] = (
+                            DictionaryItem(strokes, translation, dictionary),
+                            True
+                        )
+                if duplicates:
+                    # Include entries with matching strokes and translations.
+                    duplicated = False
+                    pair = (strokes, translation)
+                    if pair in entries_by_strokes_translation:
+                        duplicated = True
+                        dupe, new = entries_by_strokes_translation[pair]
+                        if new:
+                            prior_entry = dupe
+                            entries_by_strokes_translation[pair] = (
+                                dupe, False
+                            )
+                    else:
+                        entries_by_strokes_translation[pair] = (
+                            DictionaryItem(strokes, translation, dictionary),
+                            True
+                        )
+                # If we find a duplicate or collision, then we need to add both
+                # the current stroke, and the one we collided with / duplicated.
+                if prior_entry and filter_entry_custom(prior_entry.strokes,
+                                                       prior_entry.translation):
+                    self._entries.append(prior_entry)
+                if not collisions and not duplicates or collided or duplicated:
+                    if filter_entry(strokes, translation, strokes_filter,
+                                    translation_filter, case_sensitive, regex):
+                        self._entries.append(
+                            DictionaryItem(strokes, translation, dictionary)
+                        )
         self.sort(self._sort_column, self._sort_order)
 
     @property
@@ -195,10 +249,12 @@ class DictionaryItemModel(QAbstractTableModel):
         return Qt.ItemIsEnabled | Qt.ItemIsSelectable | editable
 
     def filter(self, strokes_filter=None, translation_filter=None,
-               case_sensitive=False, regex=None):
+               case_sensitive=False, regex=None, collisions=False,
+               duplicates=False):
         self.modelAboutToBeReset.emit()
         self._update_entries(
-            strokes_filter, translation_filter, case_sensitive, regex
+            strokes_filter, translation_filter, case_sensitive, regex,
+            collisions, duplicates
         )
         self.modelReset.emit()
 
@@ -331,6 +387,12 @@ class DictionaryEditor(QDialog, Ui_DictionaryEditor, WindowState):
                                      background-color: %s;
                                      color: %s;
                                 }''' % (background, text_color))
+
+        # Sidebar should take minimal space
+        self.splitter.setStretchFactor(0, 0)
+        # Table stretches
+        self.splitter.setStretchFactor(1, 1)
+
         self.table.setFocus()
         for action in (
             self.action_Undo,
@@ -438,6 +500,8 @@ class DictionaryEditor(QDialog, Ui_DictionaryEditor, WindowState):
         unescaped_translation_filter = unescape_translation(translation_filter)
         case_sensitive = self.case_checkbox.checkState()
         is_regex = self.regex_checkbox.checkState()
+        collisions = self.collisions_checkbox.checkState()
+        duplicates = self.duplicates_checkbox.checkState()
         try:
             regex = re.compile(
                 translation_filter, flags=0 if case_sensitive else re.I
@@ -456,13 +520,16 @@ class DictionaryEditor(QDialog, Ui_DictionaryEditor, WindowState):
                 strokes_filter=None
                 case_sensitive=None
         self._model.filter(strokes_filter, unescaped_translation_filter,
-                           case_sensitive, regex)
+                           case_sensitive, regex, collisions,
+                           duplicates)
 
     def on_clear_filter(self):
         self.strokes_filter.setText('')
         self.translation_filter.setText('')
         self.case_checkbox.setChecked(False)
         self.regex_checkbox.setChecked(False)
+        self.collisions_checkbox.setChecked(False)
+        self.duplicates_checkbox.setChecked(False)
         self._model.filter()
 
     def on_finished(self, result):

--- a/plover/gui_qt/dictionary_editor.ui
+++ b/plover/gui_qt/dictionary_editor.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>658</width>
+    <width>777</width>
     <height>560</height>
    </rect>
   </property>
@@ -17,126 +17,245 @@
    <bool>true</bool>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>-1</number>
+   </property>
    <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="title">
-      <string>Filter</string>
+    <widget class="QSplitter" name="splitter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>1</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
      </property>
-     <property name="flat">
-      <bool>false</bool>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="2">
-       <widget class="QPushButton" name="clear_button">
-        <property name="text">
-         <string>Clear</string>
-        </property>
-        <property name="autoDefault">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="stroke_label">
-        <property name="text">
-         <string>By strokes:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="strokes_filter"/>
-      </item>
-      <item row="0" column="2">
-       <widget class="QPushButton" name="filter_button">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Filter</string>
-        </property>
-        <property name="autoDefault">
-         <bool>false</bool>
-        </property>
-        <property name="default">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLineEdit" name="translation_filter"/>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="translation_label">
-        <property name="text">
-         <string>By translation:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QCheckBox" name="case_checkbox">
-          <property name="text">
-           <string>Case sensitive</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="regex_checkbox">
-          <property name="text">
-           <string>RegEx</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QTableView" name="table">
-     <property name="frameShape">
-      <enum>QFrame::Box</enum>
-     </property>
-     <property name="showDropIndicator" stdset="0">
-      <bool>true</bool>
-     </property>
-     <property name="dragEnabled">
-      <bool>true</bool>
-     </property>
-     <property name="dragDropOverwriteMode">
-      <bool>false</bool>
-     </property>
-     <property name="dragDropMode">
-      <enum>QAbstractItemView::DragDrop</enum>
-     </property>
-     <property name="defaultDropAction">
-      <enum>Qt::IgnoreAction</enum>
-     </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-     <property name="textElideMode">
-      <enum>Qt::ElideMiddle</enum>
-     </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="verticalHeaderCascadingSectionResizes">
-      <bool>true</bool>
-     </attribute>
+     <widget class="QWidget" name="layoutWidget">
+      <layout class="QGridLayout" name="gridLayout">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetMinimumSize</enum>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <property name="spacing">
+        <number>10</number>
+       </property>
+       <item row="5" column="0">
+        <widget class="QCheckBox" name="case_checkbox">
+         <property name="text">
+          <string>Case sensitive</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QPushButton" name="clear_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Clear</string>
+         </property>
+         <property name="autoDefault">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0" colspan="2">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="translation_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Translation</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QPushButton" name="filter_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Filter</string>
+         </property>
+         <property name="autoDefault">
+          <bool>false</bool>
+         </property>
+         <property name="default">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0" colspan="2">
+        <widget class="QLineEdit" name="translation_filter">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="collisions_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Show only</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QCheckBox" name="regex_checkbox">
+         <property name="text">
+          <string>RegEx</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="QLineEdit" name="strokes_filter">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QCheckBox" name="collisions_checkbox">
+         <property name="toolTip">
+          <string>Find entries that have matching strokes but different translations</string>
+         </property>
+         <property name="text">
+          <string>Collisions</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="stroke_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Strokes</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <widget class="QCheckBox" name="duplicates_checkbox">
+         <property name="toolTip">
+          <string>Find entries that have matching strokes and translations</string>
+         </property>
+         <property name="text">
+          <string>Duplicates</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QTableView" name="table">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Maximum" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::Box</enum>
+      </property>
+      <property name="showDropIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="dragEnabled">
+       <bool>true</bool>
+      </property>
+      <property name="dragDropOverwriteMode">
+       <bool>false</bool>
+      </property>
+      <property name="dragDropMode">
+       <enum>QAbstractItemView::DragDrop</enum>
+      </property>
+      <property name="defaultDropAction">
+       <enum>Qt::IgnoreAction</enum>
+      </property>
+      <property name="alternatingRowColors">
+       <bool>true</bool>
+      </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
+      <property name="textElideMode">
+       <enum>Qt::ElideMiddle</enum>
+      </property>
+      <property name="sortingEnabled">
+       <bool>true</bool>
+      </property>
+      <attribute name="horizontalHeaderStretchLastSection">
+       <bool>true</bool>
+      </attribute>
+      <attribute name="verticalHeaderCascadingSectionResizes">
+       <bool>true</bool>
+      </attribute>
+     </widget>
     </widget>
    </item>
   </layout>
@@ -187,6 +306,17 @@
   </action>
  </widget>
  <layoutdefault spacing="5" margin="8"/>
+ <tabstops>
+  <tabstop>strokes_filter</tabstop>
+  <tabstop>translation_filter</tabstop>
+  <tabstop>case_checkbox</tabstop>
+  <tabstop>regex_checkbox</tabstop>
+  <tabstop>collisions_checkbox</tabstop>
+  <tabstop>duplicates_checkbox</tabstop>
+  <tabstop>filter_button</tabstop>
+  <tabstop>clear_button</tabstop>
+  <tabstop>table</tabstop>
+ </tabstops>
  <resources>
   <include location="resources/resources.qrc"/>
  </resources>
@@ -262,43 +392,11 @@
    <slot>on_apply_filter()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>605</x>
-     <y>36</y>
+     <x>258</x>
+     <y>210</y>
     </hint>
     <hint type="destinationlabel">
-     <x>328</x>
-     <y>279</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>strokes_filter</sender>
-   <signal>returnPressed()</signal>
-   <receiver>DictionaryEditor</receiver>
-   <slot>on_apply_filter()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>352</x>
-     <y>22</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>328</x>
-     <y>279</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>translation_filter</sender>
-   <signal>returnPressed()</signal>
-   <receiver>DictionaryEditor</receiver>
-   <slot>on_apply_filter()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>352</x>
-     <y>51</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>328</x>
+     <x>388</x>
      <y>279</y>
     </hint>
    </hints>
@@ -310,11 +408,11 @@
    <slot>on_clear_filter()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>597</x>
-     <y>80</y>
+     <x>94</x>
+     <y>210</y>
     </hint>
     <hint type="destinationlabel">
-     <x>328</x>
+     <x>388</x>
      <y>279</y>
     </hint>
    </hints>

--- a/plover/steno_dictionary.py
+++ b/plover/steno_dictionary.py
@@ -64,11 +64,14 @@ class StenoDictionary(collections.MutableMapping):
     def __contains__(self, key):
         return self.get(key) is not None
 
+    def __lt__(self, other):
+        return self.get_path() < other.get_path()
+
     def set_path(self, path):
         self._path = path    
 
     def get_path(self):
-        return self._path    
+        return self._path
 
     @property
     def _longest_key(self):


### PR DESCRIPTION
### About

Add the ability to only include (collisions || duplicates) while searching.

Collisions: matching stroke but differing translation

Duplicates: matching stroke and translation

### Issues

Fixes #9

### Feedback

I'd like code and UI feedback if possible, @Germanika @sofa13 

The UI is a little messy and the code may be complex. I still need to fix testing to ensure the tests only get run in the right environment. I'm pushing it to start running CI.