### PR TITLE
Single dictionary editor instance is now managed by dictionaries widget

### DIFF
--- a/plover/gui_qt/dictionary_editor.py
+++ b/plover/gui_qt/dictionary_editor.py
@@ -302,6 +302,7 @@ class DictionaryEditor(QDialog, Ui_DictionaryEditor, WindowState):
                 for dictionary in engine.dictionaries.dicts
                 if dictionary.get_path() in dictionary_paths
             ]
+        self.dictionary_paths = dictionary_paths
         sort_column, sort_order = 0, Qt.AscendingOrder
         self._model = DictionaryItemModel(dictionary_list,
                                           sort_column,

--- a/plover/gui_qt/dictionary_editor.ui
+++ b/plover/gui_qt/dictionary_editor.ui
@@ -2,9 +2,6 @@
 <ui version="4.0">
  <class>DictionaryEditor</class>
  <widget class="QDialog" name="DictionaryEditor">
-  <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
-  </property>
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
Now the dictionary editor is a non-blocking modal, meaning you can still do other stuff in the meanwhile. I made it single instance, and it runs away if you remove a dictionary you are editing.