### PR TITLE
Handle rtf conversion failure

### DIFF
--- a/plover/dictionary/base.py
+++ b/plover/dictionary/base.py
@@ -78,11 +78,11 @@ def save_dictionary(d, filename, saver):
     # Write the new file to a temp location.
     tmp = filename + '.tmp'
     with open(tmp, 'wb') as fp:
-        error_msg = saver(d, fp)
+        failed_entries = saver(d, fp)
 
     # Then move the new file to the final location.
     shutil.move(tmp, filename)
-    return error_msg
+    return failed_entries
 
 def convert_dictionary(read_path, write_path):
     dict_in = load_dictionary(read_path)
@@ -101,7 +101,7 @@ class ThreadedSaver(object):
         self.filename = filename
         self.saver = saver
         self.lock = threading.Lock()
-        self.error_msg = ''
+        self.failed_entries = None
         
     def __call__(self):
         t = threading.Thread(target=self.save)
@@ -109,4 +109,4 @@ class ThreadedSaver(object):
         
     def save(self):
         with self.lock:
-            self.error_msg = save_dictionary(self.d, self.filename, self.saver)
+            self.failed_entries = save_dictionary(self.d, self.filename, self.saver)

--- a/plover/dictionary/base.py
+++ b/plover/dictionary/base.py
@@ -15,6 +15,7 @@ import threading
 # Python 2/3 compatibility.
 from six import reraise
 
+
 import plover.dictionary.json_dict as json_dict
 import plover.dictionary.rtfcre_dict as rtfcre_dict
 from plover.config import JSON_EXTENSION, RTF_EXTENSION
@@ -77,16 +78,18 @@ def save_dictionary(d, filename, saver):
     # Write the new file to a temp location.
     tmp = filename + '.tmp'
     with open(tmp, 'wb') as fp:
-        saver(d, fp)
+        error_msg = saver(d, fp)
 
     # Then move the new file to the final location.
     shutil.move(tmp, filename)
+    return error_msg
 
 def convert_dictionary(read_path, write_path):
     dict_in = load_dictionary(read_path)
     dict_out = create_dictionary(write_path)
     dict_out.update(dict_in)
     dict_out.save()
+    return dict_out
     
 class ThreadedSaver(object):
     """A callable that saves a dictionary in the background.
@@ -98,6 +101,7 @@ class ThreadedSaver(object):
         self.filename = filename
         self.saver = saver
         self.lock = threading.Lock()
+        self.error_msg = ''
         
     def __call__(self):
         t = threading.Thread(target=self.save)
@@ -105,4 +109,4 @@ class ThreadedSaver(object):
         
     def save(self):
         with self.lock:
-            save_dictionary(self.d, self.filename, self.saver)
+            self.error_msg = save_dictionary(self.d, self.filename, self.saver)

--- a/plover/dictionary/rtfcre_dict.py
+++ b/plover/dictionary/rtfcre_dict.py
@@ -336,15 +336,15 @@ def save_dictionary(d, fp):
     writer = codecs.getwriter('cp1252')(fp)
     writer.write(HEADER)
 
-    error_msg = ''
+    failed_entries = []
     for s, t in d.items():
         s = '/'.join(s)
         t = format_translation(t)
         entry = "{\\*\\cxs %s}%s\r\n" % (s, t)
         try:
             writer.write(entry)
-        except Exception:
-            error_msg = error_msg + entry + "\n"
+        except UnicodeEncodeError:
+            failed_entries.append((entry, _('Plover does not support Unicode characters in RTF')))
             log.info(
                 'Error while converting dictionary entry: %s',
                 entry,
@@ -352,7 +352,8 @@ def save_dictionary(d, fp):
             )
 
     writer.write("}\r\n")
-    return error_msg
+    return failed_entries
 
 def create_dictionary():
     return StenoDictionary()
+

--- a/plover/dictionary/rtfcre_dict.py
+++ b/plover/dictionary/rtfcre_dict.py
@@ -20,6 +20,7 @@ import re
 # Python 2/3 compatibility.
 from six import get_function_code
 
+from plover import log
 from plover.resource import resource_stream
 from plover.steno import normalize_steno
 from plover.steno_dictionary import StenoDictionary
@@ -335,13 +336,23 @@ def save_dictionary(d, fp):
     writer = codecs.getwriter('cp1252')(fp)
     writer.write(HEADER)
 
+    error_msg = ''
     for s, t in d.items():
         s = '/'.join(s)
         t = format_translation(t)
         entry = "{\\*\\cxs %s}%s\r\n" % (s, t)
-        writer.write(entry)
+        try:
+            writer.write(entry)
+        except Exception:
+            error_msg = error_msg + entry + "\n"
+            log.info(
+                'Error while converting dictionary entry: %s',
+                entry,
+                exc_info = True
+            )
 
     writer.write("}\r\n")
+    return error_msg
 
 def create_dictionary():
     return StenoDictionary()

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -354,7 +354,7 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
                     self._update_dictionaries(dictionaries)
 
                 try:
-                    entries = result.save.failed_entries
+                    failed_entries = result.save.failed_entries
                 except:
                     log.error(
                         'Error while retrieving converting message: %s',
@@ -362,12 +362,12 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
                         exc_info=True
                     )
                 else:
-                    if entries != None:
-                        failed_entries = ''
-                        for item in entries:
-                            failed_entries = failed_entries + '\n\n' + item[0] + item[1]
+                    if len(failed_entries) != 0:
+                        failed_entries_formatted = ''
+                        for item in failed_entries:
+                            failed_entries_formatted = failed_entries_formatted + '\n\n' + item[0] + item[1]
                         msg = ('The following dictionary entries were not saved due to conversion errors: %s'
-                               % (failed_entries)
+                               % (failed_entries_formatted)
                                )
                         MyCustomDialog(msg).exec()
 

--- a/plover/gui_qt/dictionaries_widget.py
+++ b/plover/gui_qt/dictionaries_widget.py
@@ -328,7 +328,7 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
                     shutil.copyfile(filename, new_filename)
                 else:
                     open(new_filename, 'w')
-                    convert_dictionary(filename, new_filename)
+                    result = convert_dictionary(filename, new_filename)
             except Exception:
                 log.error(
                     'Error while saving new dictionary: %s',
@@ -349,3 +349,14 @@ class DictionariesWidget(QWidget, Ui_DictionariesWidget):
                     if new_filename not in self._dictionaries:
                         dictionaries.append(new_filename)
                     self._update_dictionaries(dictionaries)
+
+                entries = result.save.error_msg
+                msg = ('The following dictionary entries were not saved due to conversion errors: \n\n %s'
+                             % (entries)
+                             )
+                if entries != '':
+                    QMessageBox.information(
+                        self, 'Conversion Errors', msg,
+                        QMessageBox.Ok,
+                        QMessageBox.Ok
+                    )


### PR DESCRIPTION
Fixes #22 

Initial implementation, to handle the rtf conversion failure.
Used try catch to catch the entries causing failure, continued converting the rest of the entries, and provided an information dialog indicating which entries failed.